### PR TITLE
Add exec permissions to start.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ COPY scripts/start.sh /app/
 
 COPY dist/mikrotik-exporter_linux_${BINARY_ARCH} /app/mikrotik-exporter
 
+RUN chmod +x /app/start.sh
+
 ENTRYPOINT ["/app/start.sh"]


### PR DESCRIPTION
This PR fixes `start.sh` exec error when you run Docker image.