### PR TITLE
Fix start.sh exec permissions for arm docker images

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -10,4 +10,6 @@ COPY scripts/start.sh /app/
 
 COPY dist/mikrotik-exporter_linux_${BINARY_ARCH} /app/mikrotik-exporter
 
+RUN chmod +x /app/start.sh
+
 ENTRYPOINT ["/app/start.sh"]


### PR DESCRIPTION
The issue https://github.com/hatamiarash7/Mikrotik-Exporter/issues/4 is still reproducible when using arm docker images. 
Looks like this PR https://github.com/hatamiarash7/Mikrotik-Exporter/pull/5 was merged around the same time a dedicated Dockerfile was created https://github.com/hatamiarash7/Mikrotik-Exporter/commit/5506f7aaea66ea36fc23be1f5cc3603a708698b5 for arm images was created and somehow the permissions fix got left out.

This PR should fix the issue.